### PR TITLE
Blog Post: Camping Along the ADT

### DIFF
--- a/src/content/posts/camping-along-the-adt.md
+++ b/src/content/posts/camping-along-the-adt.md
@@ -31,7 +31,7 @@ We got back to the campsite and started preparing dinner. I helped out some but 
 
 ![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC08112-Enhanced-NR.jpg)
 
-Almost every trop we forget at least something and this time we forgot the oil for the griddle. We made do with the grease from the steaks and a few pieces of bacon we stole from breakfast. In the end though, our steak fajitas turned out amazing! Great work Carson and Levi!
+Almost every trip we forget at least something and this time we forgot the oil for the griddle. We made do with the grease from the steaks and a few pieces of bacon we stole from breakfast. In the end though, our steak fajitas turned out amazing! Great work Carson and Levi!
 
 ![](https://static.lukebouch.com/posts/camping-along-the-adt/IMG_3956.jpg)
 

--- a/src/content/posts/camping-along-the-adt.md
+++ b/src/content/posts/camping-along-the-adt.md
@@ -1,0 +1,22 @@
+---
+title: Camping Along the ADT
+publish_date: 2023-06-21T23:41:00+00:00
+---
+
+On May 18th, my cousin left Delaware on foot to walk across the United States following the [American Discovery Trail](https://discoverytrail.org). His brother, my brother, I decided to plan a trip to meet up with him in West Virginia and cap with him.
+
+We headed out of town all loaded up on Saturday June 3rd. It took us longer than expected but we arrived at Indian Head Campground just outside of Maysville, WV, around 1:30pm. After dropping my teardrop, we headed down the road about 10 miles to puck up Ben since he had not quite made it to the campsite.
+
+After we brought Ben back to the campsite and got our stuff setup, Ben and Carson wanted to go rock climbing at a near by preserve ([Bear Rock Preserve](https://www.nature.org/en-us/get-involved/how-to-help/places-we-protect/bear-rocks-preserve/)). It was only about 25mins away. I brought my camera along to get some photos of them climbing but also came away with some amazing landscape photos. Here are a few of the best ones.
+
+(add photos here)
+
+We got back to the campsite and started preparing dinner. I helped out some but Carson and Levi seemed to enjoy cooking and so I stepped back.
+
+Almost every trop we forget at least something and this time we forgot the oil for the griddle. We made do with the grease from the steaks and a few pieces of bacon we stole from breakfast. In the end though, our steak fajitas turned out amazing! Great work Carson and Levi!
+
+The rain held off the whole day but just as we were winding down and about to go to bed, it started to rain. We were fairly well protected by the trees we were under but we could hear thunder off in the distance.
+
+On Sunday evening, we cooked another amazing meal (eggs and bacon), enjoyed each others company, packed up, and then dropped Ben off where we picked him up the day prior before heading home.
+
+Overall, Indian Head Campground was a pleasant place to stay. At night it got a little loud because it is located quite close to a main road. If you are planning to stay at the campground you should not expect much in the way of amenities. There is WiFi that works ok if you walk a few hundred feet from where we camped and there is a place to throw trash. But as far as bathrooms and showers go, you need to bring your own.

--- a/src/content/posts/camping-along-the-adt.md
+++ b/src/content/posts/camping-along-the-adt.md
@@ -9,14 +9,36 @@ We headed out of town all loaded up on Saturday June 3rd. It took us longer than
 
 After we brought Ben back to the campsite and got our stuff setup, Ben and Carson wanted to go rock climbing at a near by preserve ([Bear Rock Preserve](https://www.nature.org/en-us/get-involved/how-to-help/places-we-protect/bear-rocks-preserve/)). It was only about 25mins away. I brought my camera along to get some photos of them climbing but also came away with some amazing landscape photos. Here are a few of the best ones.
 
-(add photos here)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/IMG_3918.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/IMG_3927.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07581-Enhanced-NR.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07579.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07570.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07572.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07576.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/IMG_3940.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07618.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07600.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07586.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07593.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07853.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07584.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07862-HDRPanorama.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC08106-HDR-Pano.jpg)
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC07728-HDR-Pano.jpg)
 
 We got back to the campsite and started preparing dinner. I helped out some but Carson and Levi seemed to enjoy cooking and so I stepped back.
 
+![](https://static.lukebouch.com/posts/camping-along-the-adt/DSC08112-Enhanced-NR.jpg)
+
 Almost every trop we forget at least something and this time we forgot the oil for the griddle. We made do with the grease from the steaks and a few pieces of bacon we stole from breakfast. In the end though, our steak fajitas turned out amazing! Great work Carson and Levi!
+
+![](https://static.lukebouch.com/posts/camping-along-the-adt/IMG_3956.jpg)
 
 The rain held off the whole day but just as we were winding down and about to go to bed, it started to rain. We were fairly well protected by the trees we were under but we could hear thunder off in the distance.
 
 On Sunday evening, we cooked another amazing meal (eggs and bacon), enjoyed each others company, packed up, and then dropped Ben off where we picked him up the day prior before heading home.
+
+![](https://static.lukebouch.com/posts/camping-along-the-adt/IMG_3964.jpg)
 
 Overall, Indian Head Campground was a pleasant place to stay. At night it got a little loud because it is located quite close to a main road. If you are planning to stay at the campground you should not expect much in the way of amenities. There is WiFi that works ok if you walk a few hundred feet from where we camped and there is a place to throw trash. But as far as bathrooms and showers go, you need to bring your own.

--- a/src/content/posts/camping-along-the-adt.md
+++ b/src/content/posts/camping-along-the-adt.md
@@ -1,6 +1,6 @@
 ---
 title: Camping Along the ADT
-publish_date: 2023-06-21T23:41:00+00:00
+publish_date: 2023-06-23T02:10:47+00:00
 ---
 
 On May 18th, my cousin left Delaware on foot to walk across the United States following the [American Discovery Trail](https://discoverytrail.org). His brother, my brother, I decided to plan a trip to meet up with him in West Virginia and cap with him.


### PR DESCRIPTION
This PR adds a blog post about camping along the American Discovery Route.

## Todo

- [x] Add photos from trip
- [x] Update `publish_date`